### PR TITLE
Bump minimum cmake version to 3.5

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,6 +1,6 @@
-# 3.5 is actually available almost everywhere, but this a good minimum.
+# 3.5 is actually available almost everywhere so this a good minimum.
 # 3.14 as the upper policy limit avoids CMake deprecation warnings.
-cmake_minimum_required(VERSION 3.4...3.14)
+cmake_minimum_required(VERSION 3.5...3.14)
 
 # enable MSVC_RUNTIME_LIBRARY target property
 # see https://cmake.org/cmake/help/latest/policy/CMP0091.html


### PR DESCRIPTION
This pull request includes a minor change to the `CMakeLists.txt` file. The change corrects a comment typo and updates the minimum required CMake version.

Changes to `CMakeLists.txt`:

* Corrected a comment typo: changed "this a good minimum" to "so this a good minimum."
* Updated the minimum required CMake version from 3.4 to 3.5.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Chores**
	- Revised build configuration for improved clarity.
	- Updated the minimum required version of the build tool to enable enhanced functionalities, which may affect compatibility with older versions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->